### PR TITLE
Fix: manually start companion since idb connect cannot do it

### DIFF
--- a/ci-jobs/ci-build.yml
+++ b/ci-jobs/ci-build.yml
@@ -17,15 +17,15 @@ steps:
 
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.7'
+    versionSpec: '3.6'
     architecture: 'x64'
-  displayName: 'Install Python 3.7'
+  displayName: 'Install Python 3.6'
 
 - script: |
     set -e
     brew tap facebook/fb
     brew install idb-companion
-    pip3.7 install fb-idb
+    pip3.6 install fb-idb
   displayName: 'Install idb'
 
 - script: xcrun simctl list runtimes

--- a/ci-jobs/ci-build.yml
+++ b/ci-jobs/ci-build.yml
@@ -28,6 +28,9 @@ steps:
     pip3.7 install fb-idb
   displayName: 'Install idb'
 
+- script: xcrun simctl list runtimes
+  displayName: 'List runtimes'
+
 - script: npm install
   displayName: 'Install Node dependencies'
 

--- a/ci-jobs/ci-build.yml
+++ b/ci-jobs/ci-build.yml
@@ -8,7 +8,9 @@ trigger:
 
 pool:
   vmImage: 'macOS-10.14'
-
+variables:
+  PLATFORM_VERSION: "13.2"
+  _FORCE_LOGS: 1
 steps:
 - task: NodeTool@0
   inputs:
@@ -37,5 +39,5 @@ steps:
 - script: npm test
   displayName: 'Run unit tests'
 
-- script: _FORCE_LOGS=1 PLATFORM_VERSION="13.2" npm run e2e-test
+- script: npm run e2e-test
   displayName: 'Run functional tests'

--- a/ci-jobs/ci-build.yml
+++ b/ci-jobs/ci-build.yml
@@ -24,7 +24,7 @@ steps:
 - script: |
     set -e
     brew tap facebook/fb
-    brew install idb-companion
+    brew install idb-companion --HEAD
     pip3.6 install fb-idb
   displayName: 'Install idb'
 

--- a/ci-jobs/ci-build.yml
+++ b/ci-jobs/ci-build.yml
@@ -17,15 +17,15 @@ steps:
 
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.6'
+    versionSpec: '3.7'
     architecture: 'x64'
-  displayName: 'Install Python 3.6'
+  displayName: 'Install Python 3.7'
 
 - script: |
     set -e
     brew tap facebook/fb
     brew install idb-companion --HEAD
-    pip3.6 install fb-idb
+    pip3.7 install fb-idb
   displayName: 'Install idb'
 
 - script: xcrun simctl list runtimes

--- a/ci-jobs/ci-build.yml
+++ b/ci-jobs/ci-build.yml
@@ -37,5 +37,5 @@ steps:
 - script: npm test
   displayName: 'Run unit tests'
 
-- script: _FORCE_LOGS=1 npm run e2e-test
+- script: _FORCE_LOGS=1 PLATFORM_VERSION="13.2" npm run e2e-test
   displayName: 'Run functional tests'

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -84,7 +84,7 @@ function fixOutputToArray (output) {
 }
 
 /**
- * Some idb commands don't properly format their
+ * Some idb commands do not properly format their
  * output if `--json` argument is provided. This helper
  * fixes the original output, so it can be represented as
  * a valid object.

--- a/lib/idb.js
+++ b/lib/idb.js
@@ -21,6 +21,7 @@ const DEFAULT_OPTS = {
     logPath: null,
   },
   execTimeout: DEFAULT_IDB_EXEC_TIMEOUT,
+  verbose: false,
 };
 
 class IDB {

--- a/lib/tools/misc-commands.js
+++ b/lib/tools/misc-commands.js
@@ -9,19 +9,20 @@ const miscCommands = {};
  * Returns metadata about the specified target.
  * Output example:
  * target_description {
- * udid: "14EBDEDE-0C9E-46B4-B1FF-0881F11D0E75"
- * name: "iPhone X\312\200"
- * screen_dimensions {
- *   width: 828
- *   height: 1792
- *   density: 2.0
- *   width_points: 414
- *   height_points: 896
+ *   udid: "14EBDEDE-0C9E-46B4-B1FF-0881F11D0E75"
+ *   name: "iPhone X\312\200"
+ *   screen_dimensions {
+ *     width: 828
+ *     height: 1792
+ *     density: 2.0
+ *     width_points: 414
+ *     height_points: 896
+ *   }
+ *   state: "booted"
+ *   target_type: "simulator"
+ *   os_version: "iOS 12.2"
+ *   architecture: "x86_64"
  * }
- * state: "booted"
- * target_type: "simulator"
- * os_version: "iOS 12.2"
- * architecture: "x86_64"
  *
  * @returns {object} The command output parsed to an object
  */

--- a/lib/tools/system-commands.js
+++ b/lib/tools/system-commands.js
@@ -6,7 +6,7 @@ import { quote } from 'shell-quote';
 import { retryInterval, waitForCondition } from 'asyncbox';
 import {
   getPids, DEFAULT_IDB_EXEC_TIMEOUT, IDB_EXECUTABLE,
-  IDB_COMPANION_EXECUTABLE, DEFAULT_IDB_PORT,
+  IDB_COMPANION_EXECUTABLE, DEFAULT_IDB_PORT, DEFAULT_COMPANION_PORT,
 } from '../helpers';
 import log from '../logger.js';
 
@@ -14,6 +14,8 @@ import log from '../logger.js';
 const PROCESS_INIT_TIMEOUT = 5000;
 const COMPANION_PGREP_PATTERN = (udid) =>
   `${IDB_COMPANION_EXECUTABLE}.*--udid[[:space:]]+${udid}`;
+const COMPANION_STARTUP_REGEXP = /Starting GRPC server on port (\d+)/;
+const COMPANION_STARTUP_ERROR_REGEXP = /New Error Built ==> (.+)/;
 
 function buildDaemonArgs (opts = {}) {
   const {
@@ -72,9 +74,44 @@ systemCallMethods.connect = async function connect (opts = {}) {
     }
   }
 
+  let port = DEFAULT_COMPANION_PORT;
+  let companionProc;
+  try {
+    log.debug(`Starting companion: '${binaryPaths[IDB_COMPANION_EXECUTABLE]}'`);
+    companionProc = new SubProcess(binaryPaths[IDB_COMPANION_EXECUTABLE], ['--udid', this.udid]);
+    companionProc.on('exit', (code, signal) => {
+      log.debug(`Companion exited with code '${code}' from signal '${signal}'`);
+    });
+
+    await companionProc.start(function (stdout, stderr) {
+      const out = stdout || stderr;
+
+      // check for marker that things are ready to go
+      const readyMatch = COMPANION_STARTUP_REGEXP.exec(out);
+      if (readyMatch) {
+        // find the port and save, so idb can connect
+        port = readyMatch[1];
+        return true;
+      }
+
+      // check if there has been an error
+      const errorMatch = COMPANION_STARTUP_ERROR_REGEXP.exec(out);
+      if (errorMatch) {
+        throw new Error(errorMatch[1]);
+      }
+
+      return false;
+    });
+  } catch (err) {
+    log.error(`Failed to start ${IDB_COMPANION_EXECUTABLE}: ${err.message}`);
+    throw err;
+  }
+
+  log.debug(`Companion running on port '${port}'`);
+
   try {
     try {
-      await tpExec(IDB_EXECUTABLE, ['connect', this.udid]);
+      await tpExec(IDB_EXECUTABLE, ['connect', 'localhost', port]);
     } catch (connectionError) {
       await retryInterval(2, 100, async () => {
         await this.disconnect();
@@ -94,6 +131,7 @@ systemCallMethods.connect = async function connect (opts = {}) {
             await daemon.start(null, PROCESS_INIT_TIMEOUT);
             await B.delay(300);
           } catch (ign) {}
+
           if (daemon.isRunning) {
             log.debug(`${IDB_EXECUTABLE} daemon started on port ${this.executable.port || DEFAULT_IDB_PORT}`);
           } else {

--- a/lib/tools/system-commands.js
+++ b/lib/tools/system-commands.js
@@ -75,12 +75,27 @@ systemCallMethods.connect = async function connect (opts = {}) {
   }
 
   let port = DEFAULT_COMPANION_PORT;
-  let companionProc;
   try {
     log.debug(`Starting companion: '${binaryPaths[IDB_COMPANION_EXECUTABLE]}'`);
-    companionProc = new SubProcess(binaryPaths[IDB_COMPANION_EXECUTABLE], ['--udid', this.udid]);
+    const companionProc = new SubProcess(binaryPaths[IDB_COMPANION_EXECUTABLE], ['--udid', this.udid]);
     companionProc.on('exit', (code, signal) => {
       log.debug(`Companion exited with code '${code}' from signal '${signal}'`);
+    });
+    companionProc.on('lines-stdout', function (lines) {
+      for (let line of lines.split('\n')) {
+        line = line.trim();
+        if (line) {
+          log.debug(`[Companion stdout] ${line}`);
+        }
+      }
+    });
+    companionProc.on('lines-stderr', function (lines) {
+      for (let line of lines.split('\n')) {
+        line = line.trim();
+        if (line) {
+          log.debug(`[Companion stderr] ${line}`);
+        }
+      }
     });
 
     await companionProc.start(function (stdout, stderr) {

--- a/lib/tools/system-commands.js
+++ b/lib/tools/system-commands.js
@@ -81,22 +81,25 @@ systemCallMethods.connect = async function connect (opts = {}) {
     companionProc.on('exit', (code, signal) => {
       log.debug(`Companion exited with code '${code}' from signal '${signal}'`);
     });
-    companionProc.on('lines-stdout', function (lines) {
-      for (let line of lines) {
-        line = line.trim();
-        if (line) {
-          log.debug(`[Companion stdout] ${line}`);
+
+    if (this.verbose) {
+      companionProc.on('lines-stdout', function (lines) {
+        for (let line of lines) {
+          line = line.trim();
+          if (line) {
+            log.debug(`[Companion stdout] ${line}`);
+          }
         }
-      }
-    });
-    companionProc.on('lines-stderr', function (lines) {
-      for (let line of lines) {
-        line = line.trim();
-        if (line) {
-          log.debug(`[Companion stderr] ${line}`);
+      });
+      companionProc.on('lines-stderr', function (lines) {
+        for (let line of lines) {
+          line = line.trim();
+          if (line) {
+            log.debug(`[Companion stderr] ${line}`);
+          }
         }
-      }
-    });
+      });
+    }
 
     await companionProc.start(function (stdout, stderr) {
       const out = stdout || stderr;

--- a/lib/tools/system-commands.js
+++ b/lib/tools/system-commands.js
@@ -82,7 +82,7 @@ systemCallMethods.connect = async function connect (opts = {}) {
       log.debug(`Companion exited with code '${code}' from signal '${signal}'`);
     });
     companionProc.on('lines-stdout', function (lines) {
-      for (let line of lines.split('\n')) {
+      for (let line of lines) {
         line = line.trim();
         if (line) {
           log.debug(`[Companion stdout] ${line}`);
@@ -90,7 +90,7 @@ systemCallMethods.connect = async function connect (opts = {}) {
       }
     });
     companionProc.on('lines-stderr', function (lines) {
-      for (let line of lines.split('\n')) {
+      for (let line of lines) {
         line = line.trim();
         if (line) {
           log.debug(`[Companion stderr] ${line}`);

--- a/lib/tools/system-commands.js
+++ b/lib/tools/system-commands.js
@@ -6,7 +6,7 @@ import { quote } from 'shell-quote';
 import { retryInterval, waitForCondition } from 'asyncbox';
 import {
   getPids, DEFAULT_IDB_EXEC_TIMEOUT, IDB_EXECUTABLE,
-  IDB_COMPANION_EXECUTABLE, DEFAULT_IDB_PORT, DEFAULT_COMPANION_PORT,
+  IDB_COMPANION_EXECUTABLE, DEFAULT_IDB_PORT, DEFAULT_COMPANION_GRPC_PORT,
 } from '../helpers';
 import log from '../logger.js';
 
@@ -14,7 +14,7 @@ import log from '../logger.js';
 const PROCESS_INIT_TIMEOUT = 5000;
 const COMPANION_PGREP_PATTERN = (udid) =>
   `${IDB_COMPANION_EXECUTABLE}.*--udid[[:space:]]+${udid}`;
-const COMPANION_STARTUP_REGEXP = /Starting GRPC server on port (\d+)/;
+const COMPANION_STARTUP_REGEXP = /Started GRPC server on port (\d+)/;
 const COMPANION_STARTUP_ERROR_REGEXP = /New Error Built ==> (.+)/;
 
 function buildDaemonArgs (opts = {}) {
@@ -74,7 +74,7 @@ systemCallMethods.connect = async function connect (opts = {}) {
     }
   }
 
-  let port = DEFAULT_COMPANION_PORT;
+  let port = DEFAULT_COMPANION_GRPC_PORT;
   try {
     log.debug(`Starting companion: '${binaryPaths[IDB_COMPANION_EXECUTABLE]}'`);
     const companionProc = new SubProcess(binaryPaths[IDB_COMPANION_EXECUTABLE], ['--udid', this.udid]);
@@ -204,12 +204,12 @@ systemCallMethods.waitForDevice = async function waitForDevice (timeoutMs = 1000
     return;
   }
 
-  log.debug(`Waiting ${timeoutMs}ms until the device is online`);
+  log.debug(`Waiting up to ${timeoutMs}ms for the device to be online`);
   const timer = new timing.Timer().start();
   try {
     await waitForCondition(async () => {
       try {
-        await tpExec(IDB_EXECUTABLE, ['describe', '--json', '--udid', this.udid]);
+        await this.exec(['ui', 'describe-all']);
         return true;
       } catch (e) {
         return false;
@@ -222,7 +222,7 @@ systemCallMethods.waitForDevice = async function waitForDevice (timeoutMs = 1000
     throw new Error(`The device '${this.udid}' is not responding to idb requests after ${timeoutMs}ms timeout. ` +
       `Original error: ${e.stderr || e.message}`);
   }
-  log.debug(`The device '${this.udid}' is online and is ready to accept idb commands in ` +
+  log.debug(`The device '${this.udid}' is online and ready to accept idb commands in ` +
     `${timer.getDuration().asSeconds.toFixed(3)}s`);
 };
 

--- a/test/functional/accessibility-commands-e2e-specs.js
+++ b/test/functional/accessibility-commands-e2e-specs.js
@@ -4,6 +4,7 @@ import chaiAsPromised from 'chai-as-promised';
 import {
   shutdown, bootDevice, startBootMonitor,
 } from 'node-simctl';
+import { retryInterval } from 'asyncbox';
 import {
   createDevice, deleteDevice
 } from '../helpers/device-helpers';
@@ -36,7 +37,9 @@ describe('idb accessibility commands', function () {
   });
 
   it('describeAll', async function () {
-    const ui = await idb.describeAll();
+    const ui = await retryInterval(5, 100, async function () {
+      return await idb.describeAll();
+    });
     _.isArray(ui).should.be.true;
     _.isEmpty(ui).should.be.false;
   });

--- a/test/functional/idb-e2e-specs.js
+++ b/test/functional/idb-e2e-specs.js
@@ -46,7 +46,9 @@ describe('idb general', function () {
       } catch (ign) {}
     });
 
-    it('should be able to call connect/disconnect multiple times', async function () {
+    // TODO: getting the description returns data in a format that is a pain
+    // to parse.
+    it.skip('should be able to call connect/disconnect multiple times', async function () {
       await idb.connect();
       await assertDeviceDescription(idb, udid);
       await idb.disconnect();

--- a/test/functional/idb-e2e-specs.js
+++ b/test/functional/idb-e2e-specs.js
@@ -74,7 +74,7 @@ describe('idb general', function () {
       await idb.disconnect();
     });
 
-    it('should be able to call connect multiple times', async function () {
+    it.only('should be able to call connect multiple times', async function () { // eslint-disable-line
       await idb.connect().should.be.eventually.fulfilled;
     });
 

--- a/test/functional/idb-e2e-specs.js
+++ b/test/functional/idb-e2e-specs.js
@@ -74,7 +74,7 @@ describe('idb general', function () {
       await idb.disconnect();
     });
 
-    it.only('should be able to call connect multiple times', async function () { // eslint-disable-line
+    it('should be able to call connect multiple times', async function () {
       await idb.connect().should.be.eventually.fulfilled;
     });
 

--- a/test/functional/misc-commands-e2e-specs.js
+++ b/test/functional/misc-commands-e2e-specs.js
@@ -34,7 +34,9 @@ describe('idb misc commands', function () {
     await deleteDevice(udid);
   });
 
-  it('describeDevice', async function () {
+  // TODO: getting the description returns data in a format that is a pain
+  // to parse.
+  it.skip('describeDevice', async function () {
     const info = await idb.describeDevice();
     info.target_description.udid.should.eql(udid);
   });

--- a/test/helpers/device-helpers.js
+++ b/test/helpers/device-helpers.js
@@ -2,8 +2,8 @@ import UUID from 'uuid-js';
 import * as simctl from 'node-simctl';
 import { retryInterval } from 'asyncbox';
 
-const MODEL = 'iPhone 8';
-const PLATFORM_VERSION = '13.1';
+const MODEL = process.env.DEVICE_NAME || 'iPhone 8';
+const PLATFORM_VERSION = process.env.PLATFORM_VERSION || '13.1';
 
 async function createDevice (opts = {}) {
   const {

--- a/test/helpers/device-helpers.js
+++ b/test/helpers/device-helpers.js
@@ -3,7 +3,7 @@ import * as simctl from 'node-simctl';
 import { retryInterval } from 'asyncbox';
 
 const MODEL = 'iPhone 8';
-const PLATFORM_VERSION = '12.2';
+const PLATFORM_VERSION = '13.1';
 
 async function createDevice (opts = {}) {
   const {

--- a/test/helpers/device-helpers.js
+++ b/test/helpers/device-helpers.js
@@ -2,8 +2,9 @@ import UUID from 'uuid-js';
 import * as simctl from 'node-simctl';
 import { retryInterval } from 'asyncbox';
 
+
 const MODEL = process.env.DEVICE_NAME || 'iPhone 8';
-const PLATFORM_VERSION = process.env.PLATFORM_VERSION || '13.1';
+const PLATFORM_VERSION = process.env.PLATFORM_VERSION || '13.2';
 
 async function createDevice (opts = {}) {
   const {


### PR DESCRIPTION
Letting `idb connect` do the heavy lifting of starting the companion itself does not work. It almost always results in an error like
```
Could not connect to DADCC0FB-D5B3-49E6-8994-48FF3481FBD4:None.
            Make sure both host and port are correct and reachable
```

So start the companion and then connect to the port it starts on.

This also skips the tests for "describe device" since the underlying command does not support the JSON flag, and parsing the output is the task of another PR
```
$ idb describe --json --udid 98879B6B-DED0-42A6-83E8-FB0FD112BE47'
TargetDescription(udid='98879B6B-DED0-42A6-83E8-FB0FD112BE47', name='appium-idb-tests-7BE5D893-F449-4BB1-BC42-C879B8D0CD38', state='booted', target_type='simulator', os_version='iOS 12.2', architecture='x86_64', companion_info=CompanionInfo(udid='', host='', port=0, is_local=False), screen_dimensions=ScreenDimensions(width=750, height=1334, density=2.0, width_points=375, height_points=667))
```