### PR TITLE
fix: move UDID between commands and params

### DIFF
--- a/ci-jobs/ci-build.yml
+++ b/ci-jobs/ci-build.yml
@@ -26,18 +26,11 @@ steps:
 - script: |
     brew tap facebook/fb
     brew install idb-companion
-    idb_companion --help
   displayName: Install IDB Companion
 
 - script: |
     python -m pip install --user fb-idb
-    idb --help
   displayName: Install IDB
-
-- script: |
-    idb_companion --help
-    idb --help
-  displayName: Verify idb_companion and idb
 
 - script: |
     /bin/bash -c "sudo xcode-select -s /Applications/Xcode_11.7.app/Contents/Developer"

--- a/ci-jobs/ci-build.yml
+++ b/ci-jobs/ci-build.yml
@@ -26,10 +26,12 @@ steps:
 - script: |
     brew tap facebook/fb
     brew install idb-companion
+    idb_companion --help
   displayName: Install IDB Companion
 
 - script: |
     python -m pip install --user fb-idb
+    idb --help
   displayName: Install IDB
 
 - script: |

--- a/ci-jobs/ci-build.yml
+++ b/ci-jobs/ci-build.yml
@@ -40,5 +40,5 @@ steps:
 - script: npm test
   displayName: 'Run unit tests'
 
-- script: npm run e2e-test
+- script: export PATH="${PATH}:$(python -c 'import site; print(site.USER_BASE)')/bin" && npm run e2e-test
   displayName: 'Run functional tests'

--- a/ci-jobs/ci-build.yml
+++ b/ci-jobs/ci-build.yml
@@ -23,13 +23,10 @@ steps:
     architecture: 'x64'
   displayName: 'Install Python 3.7'
 
-- script: |
+- bash: |
     brew tap facebook/fb
     brew install idb-companion
-  displayName: Install IDB Companion
-
-- script: |
-    python -m pip install --user fb-idb
+    /usr/local/bin/pip3 install --user fb-idb
   displayName: Install IDB
 
 - script: |

--- a/ci-jobs/ci-build.yml
+++ b/ci-jobs/ci-build.yml
@@ -23,15 +23,14 @@ steps:
     architecture: 'x64'
   displayName: 'Install Python 3.7'
 
-- script: |
-    set -e
+- bash: |
     brew tap facebook/fb
-    brew install idb-companion --HEAD
-    pip3.7 install fb-idb
-  displayName: 'Install idb'
+    brew install idb-companion
+    python -m pip install --user fb-idb
+  displayName: Install IDB
 
 - script: |
-    /bin/bash -c "sudo xcode-select -s /Applications/Xcode_11.2.app/Contents/Developer"
+    /bin/bash -c "sudo xcode-select -s /Applications/Xcode_12.0.app/Contents/Developer"
     xcrun simctl list runtimes
   displayName: 'Setup Xcode'
 

--- a/ci-jobs/ci-build.yml
+++ b/ci-jobs/ci-build.yml
@@ -9,7 +9,7 @@ trigger:
 pool:
   vmImage: 'macOS-10.15'
 variables:
-  PLATFORM_VERSION: "13.4"
+  PLATFORM_VERSION: "13.7"
   _FORCE_LOGS: 1
 steps:
 - task: NodeTool@0
@@ -26,8 +26,16 @@ steps:
 - bash: |
     brew tap facebook/fb
     brew install idb-companion
+  displayName: Install IDB Companion
+
+- bash: |
     python -m pip install --user fb-idb
   displayName: Install IDB
+
+- script: |
+    idb_companion --help
+    idb --help
+  displayName: Verify idb_companion and idb
 
 - script: |
     /bin/bash -c "sudo xcode-select -s /Applications/Xcode_11.7.app/Contents/Developer"

--- a/ci-jobs/ci-build.yml
+++ b/ci-jobs/ci-build.yml
@@ -23,12 +23,12 @@ steps:
     architecture: 'x64'
   displayName: 'Install Python 3.7'
 
-- bash: |
+- script: |
     brew tap facebook/fb
     brew install idb-companion
   displayName: Install IDB Companion
 
-- bash: |
+- script: |
     python -m pip install --user fb-idb
   displayName: Install IDB
 

--- a/ci-jobs/ci-build.yml
+++ b/ci-jobs/ci-build.yml
@@ -7,9 +7,9 @@ trigger:
 - master
 
 pool:
-  vmImage: 'macOS-10.14'
+  vmImage: 'macOS-10.15'
 variables:
-  PLATFORM_VERSION: "13.2"
+  PLATFORM_VERSION: "13.4"
   _FORCE_LOGS: 1
 steps:
 - task: NodeTool@0
@@ -30,7 +30,7 @@ steps:
   displayName: Install IDB
 
 - script: |
-    /bin/bash -c "sudo xcode-select -s /Applications/Xcode_12.0.app/Contents/Developer"
+    /bin/bash -c "sudo xcode-select -s /Applications/Xcode_11.7.app/Contents/Developer"
     xcrun simctl list runtimes
   displayName: 'Setup Xcode'
 

--- a/ci-jobs/ci-build.yml
+++ b/ci-jobs/ci-build.yml
@@ -1,44 +1,56 @@
-# Node.js
-# Build a general Node.js project with npm.
-# Add steps that analyze code, save build artifacts, deploy, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
-
-trigger:
-- master
-
-pool:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/android
+parameters:
+  script: ''
+  name: ios-e2e-test
+  dependsOn: ''
+  iosVersion: 14.0
+  xcodeVersion: 12.0
+  deviceName: 'iPhone X'
+  skipTvOs: False
   vmImage: 'macOS-10.15'
-variables:
-  PLATFORM_VERSION: "13.7"
-  _FORCE_LOGS: 1
-steps:
-- task: NodeTool@0
-  inputs:
-    versionSpec: '10.x'
-  displayName: 'Install Node.js'
 
-- task: UsePythonVersion@0
-  inputs:
-    versionSpec: '3.7'
-    architecture: 'x64'
-  displayName: 'Install Python 3.7'
-
-- bash: |
-    brew tap facebook/fb
-    brew install idb-companion
-    /usr/local/bin/pip3 install --user fb-idb
-  displayName: Install IDB
-
-- script: |
-    /bin/bash -c "sudo xcode-select -s /Applications/Xcode_11.7.app/Contents/Developer"
-    xcrun simctl list runtimes
-  displayName: 'Setup Xcode'
-
-- script: npm install
-  displayName: 'Install Node dependencies'
-
-- script: npm test
-  displayName: 'Run unit tests'
-
-- script: export PATH="${PATH}:$(python -c 'import site; print(site.USER_BASE)')/bin" && npm run e2e-test
-  displayName: 'Run functional tests'
+jobs:
+  - job: ${{ parameters.name }}
+    condition: ne(${{ parameters.skipTvOs }}, True)
+    variables:
+      PLATFORM_VERSION: ${{ parameters.iosVersion }}
+      DEVICE_NAME: ${{ parameters.deviceName }}
+      MOCHA_FILE: '${{ parameters.name }}-tests.xml'
+      LAUNCH_WITH_IDB: ${{ parameters.launchWithIDB }}
+      CI: true
+    pool:
+      vmImage: ${{ parameters.vmImage }}
+    steps:
+    - checkout: self
+    - bash: |
+        echo "Mocha output file: $MOCHA_FILE"
+        echo "Platform Version: $PLATFORM_VERSION"
+        echo "Device Name: $DEVICE_NAME"
+      displayName: Print Environment Variables
+    - script: ls /Applications/
+      displayName: List Installed Applications
+    - script: sudo xcode-select -s /Applications/Xcode_${{ parameters.xcodeVersion }}.app/Contents/Developer
+      displayName: Xcode Select ${{ parameters.xcodeVersion }}
+    - script: xcodebuild -version
+      displayName: Log Xcode Version
+    - script: xcrun simctl list
+      displayName: List Installed Simulators
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.7'
+    - bash: |
+        brew tap facebook/fb
+        brew install idb-companion
+        /usr/local/bin/pip3 install --user fb-idb
+      displayName: Install IDB
+    - task: NodeTool@0
+      inputs:
+        versionSpec: 12.x
+    - script: npm install
+      displayName: Install node dependencies
+    - script: export PATH="${PATH}:$(python3 -c 'import site; print(site.USER_BASE)')/bin" && npm run e2e-test
+      displayName: Run functional tests
+    - task: PublishTestResults@2
+      condition: always()
+      inputs:
+        testResultsFiles: $(MOCHA_FILE)

--- a/lib/tools/app-commands.js
+++ b/lib/tools/app-commands.js
@@ -63,7 +63,7 @@ appCommands.launchApp = async function launchApp (bundleId, opts = {}) {
   }
 
   const processMonitor = this.createSubProcess(
-    ['launch'], 
+    ['launch'],
     [bundleId, ...args, '--wait-for'],
   );
   await processMonitor.start(0);

--- a/lib/tools/app-commands.js
+++ b/lib/tools/app-commands.js
@@ -62,10 +62,10 @@ appCommands.launchApp = async function launchApp (bundleId, opts = {}) {
     return null;
   }
 
-  const processMonitor = this.createSubProcess([
-    'launch', bundleId,
-    ...args, '--wait-for',
-  ]);
+  const processMonitor = this.createSubProcess(
+    ['launch'], 
+    [bundleId, ...args, '--wait-for'],
+  );
   await processMonitor.start(0);
   return processMonitor;
 };

--- a/lib/tools/system-commands.js
+++ b/lib/tools/system-commands.js
@@ -293,11 +293,12 @@ systemCallMethods.exec = async function exec (cmd, opts = {}) {
  * Creates SubProcess instance of idb for background
  * execution.
  *
+ * @param {Array<String>} command desired idb command (e.g.: ["launch"], ["xctest", "run", "ui"])
  * @param {Array<String>} args additional idb arguments
  * @returns {SubProcess}
  */
-systemCallMethods.createSubProcess = function createSubProcess (args = [], opts = {}) {
-  const idbArgs = [...args, ...this.executable.defaultArgs];
+systemCallMethods.createSubProcess = function createSubProcess (command = [], args = [], opts = {}) {
+  const idbArgs = [...command, ...this.executable.defaultArgs, ...args];
   log.debug(`Creating ${IDB_EXECUTABLE} subprocess with args: ${util.quote(args)}`);
   return new SubProcess(this.executable.path, idbArgs, opts);
 };

--- a/lib/tools/xctest-commands.js
+++ b/lib/tools/xctest-commands.js
@@ -21,13 +21,15 @@ const xctestCommands = {};
 xctestCommands.runXCUITest = async function runXCUITest (
   testRunnerBundleId, appUnderTestBundleId, xctestBundleId, opts = {}
 ) {
-  const uiTestProcess = this.createSubProcess([
-    'xctest', 'run',
-    opts.testType || 'ui', xctestBundleId,
-    appUnderTestBundleId, testRunnerBundleId,
-    ...(opts.args || [])
-  ], {
-    env: convertToIDBEnv(opts.env)
+  const uiTestProcess = this.createSubProcess(
+    ['xctest', 'run', opts.testType || 'ui'], 
+    [
+      xctestBundleId,
+      appUnderTestBundleId,
+      testRunnerBundleId,
+      ...(opts.args || [])
+    ], 
+    {env: convertToIDBEnv(opts.env)
   });
   await uiTestProcess.start(0);
   return uiTestProcess;

--- a/lib/tools/xctest-commands.js
+++ b/lib/tools/xctest-commands.js
@@ -22,15 +22,15 @@ xctestCommands.runXCUITest = async function runXCUITest (
   testRunnerBundleId, appUnderTestBundleId, xctestBundleId, opts = {}
 ) {
   const uiTestProcess = this.createSubProcess(
-    ['xctest', 'run', opts.testType || 'ui'], 
+    ['xctest', 'run', opts.testType || 'ui'],
     [
       xctestBundleId,
       appUnderTestBundleId,
       testRunnerBundleId,
       ...(opts.args || [])
-    ], 
+    ],
     {env: convertToIDBEnv(opts.env)
-  });
+    });
   await uiTestProcess.start(0);
   return uiTestProcess;
 };

--- a/test/helpers/device-helpers.js
+++ b/test/helpers/device-helpers.js
@@ -3,7 +3,7 @@ import { retryInterval } from 'asyncbox';
 import Simctl from 'node-simctl';
 
 const MODEL = process.env.DEVICE_NAME || 'iPhone 8';
-const PLATFORM_VERSION = process.env.PLATFORM_VERSION || '13.2';
+const PLATFORM_VERSION = process.env.PLATFORM_VERSION || '13.7';
 
 async function prepareDevice (opts = {}) {
   const {

--- a/test/helpers/device-helpers.js
+++ b/test/helpers/device-helpers.js
@@ -3,7 +3,7 @@ import { retryInterval } from 'asyncbox';
 import Simctl from 'node-simctl';
 
 const MODEL = process.env.DEVICE_NAME || 'iPhone 8';
-const PLATFORM_VERSION = process.env.PLATFORM_VERSION || '13.7';
+const PLATFORM_VERSION = process.env.PLATFORM_VERSION || '13.2';
 
 async function prepareDevice (opts = {}) {
   const {


### PR DESCRIPTION
IDB commands seem to only work if udid comes in between the command and the parameters

_Example_
**GOOD**: `idb xctest run ui --udid <SOME_UDID> com.facebook.wda.runner com.facebook.WebDriverAgentRunner.xctrunner com.facebook.WebDriverAgentRunner.xctrunner`

**BAD**: `idb xctest run ui com.facebook.wda.runner com.facebook.WebDriverAgentRunner.xctrunner com.facebook.WebDriverAgentRunner.xctrunner --udid <SOME_UDID>`

This PR adjusts the `createSubProcess` function to address this ^