### PR TITLE
fix: describeDevice fails to parse a valid json

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ appium-idb is NodeJS wrapper over iOS Device Bridge (idb) set of utilities made 
 
 - Python 3.6 or newer
 - XCode 10 or newer
-- idb_companion
-- idb
+- idb_companion 1.1.8 or newer
+- idb 1.1.7 or newer
 
 
 ## Installation

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -83,59 +83,9 @@ function fixOutputToArray (output) {
     }, []);
 }
 
-/**
- * Some idb commands do not properly format their
- * output if `--json` argument is provided. This helper
- * fixes the original output, so it can be represented as
- * a valid object.
- *
- * @param {string} output The original command output
- * @returns {object} The parsed object or an empty object
- */
-function fixOutputToObject (output) {
-  if (!_.trim(output)) {
-    return {};
-  }
-
-  const result = {};
-  const lines = output.split('\n');
-  const getLeftIndent = (line) => line.length - _.trimStart(line).length;
-  let lineIdx = 0;
-  do {
-    if (!_.trim(lines[lineIdx])) {
-      lineIdx++;
-      continue;
-    }
-
-    const objectMatch = /(\S+)\s+{/.exec(lines[lineIdx]);
-    if (objectMatch) {
-      const currentIndent = getLeftIndent(lines[lineIdx]);
-      const startLine = lineIdx;
-      do {
-        lineIdx++;
-      } while (lineIdx < lines.length && currentIndent < getLeftIndent(lines[lineIdx]));
-      const objectName = objectMatch[1];
-      const objectContent = lines.slice(startLine + 1, lineIdx).join('\n');
-      result[objectName] = fixOutputToObject(objectContent);
-    }
-
-    const propertyMatch = /(\S+):\s+([^\n]+)/.exec(lines[lineIdx]);
-    if (propertyMatch) {
-      const propertyName = propertyMatch[1];
-      const propertyValue = propertyMatch[2].trim();
-      result[propertyName] = propertyValue.startsWith('"')
-        ? _.trim(propertyValue, '"')
-        : Number(propertyValue);
-    }
-
-    lineIdx++;
-  } while (lineIdx < lines.length);
-  return result;
-}
-
 export {
   DEFAULT_IDB_EXEC_TIMEOUT, getPids, IDB_EXECUTABLE,
   IDB_COMPANION_EXECUTABLE, DEFAULT_IDB_PORT,
   DEFAULT_COMPANION_PORT, DEFAULT_COMPANION_GRPC_PORT,
-  fixOutputToArray, fixOutputToObject, convertToIDBEnv
+  fixOutputToArray, convertToIDBEnv
 };

--- a/lib/tools/misc-commands.js
+++ b/lib/tools/misc-commands.js
@@ -1,6 +1,5 @@
 import log from '../logger.js';
 import _ from 'lodash';
-import { fixOutputToObject } from '../helpers';
 
 
 const miscCommands = {};
@@ -8,20 +7,34 @@ const miscCommands = {};
 /**
  * Returns metadata about the specified target.
  * Output example:
- * target_description {
- *   udid: "14EBDEDE-0C9E-46B4-B1FF-0881F11D0E75"
- *   name: "iPhone X\312\200"
- *   screen_dimensions {
- *     width: 828
- *     height: 1792
- *     density: 2.0
- *     width_points: 414
- *     height_points: 896
- *   }
- *   state: "booted"
- *   target_type: "simulator"
- *   os_version: "iOS 12.2"
- *   architecture: "x86_64"
+ * {
+ *   udid: 'A9391B7A-3EAF-444E-B9A5-2504A2C48E6F',
+ *   name: 'appium-idb-tests-630AAB3D-27CD-43D2-BD96-7720C42B1D54',
+ *   target_type: 'simulator',
+ *   state: 'Booted',
+ *   os_version: 'iOS 13.7',
+ *   architecture: 'x86_64',
+ *   companion_info: {
+ *     udid: 'A9391B7A-3EAF-444E-B9A5-2504A2C48E6F',
+ *     is_local: true,
+ *     pid: null,
+ *     address: {
+ *       path: '/tmp/idb/A9391B7A-3EAF-444E-B9A5-2504A2C48E6F_companion.sock'
+ *     },
+ *     metadata: {}
+ *   },
+ *   screen_dimensions: {
+ *     width: 750,
+ *     height: 1334,
+ *     density: 2,
+ *     width_points: 375,
+ *     height_points: 667
+ *   },
+ *   model: null,
+ *   device: null,
+ *   extended: {},
+ *   diagnostics: {},
+ *   metadata: {}
  * }
  *
  * @returns {object} The command output parsed to an object
@@ -29,7 +42,7 @@ const miscCommands = {};
 miscCommands.describeDevice = async function describeDevice () {
   log.debug(`Describing the device '${this.udid}'`);
   const output = await this.exec(['describe'], ['--json']);
-  return fixOutputToObject(output);
+  return JSON.parse(output);
 };
 
 /**

--- a/test/functional/idb-e2e-specs.js
+++ b/test/functional/idb-e2e-specs.js
@@ -11,7 +11,7 @@ chai.use(chaiAsPromised);
 
 async function assertDeviceDescription (idb, udid) {
   const info = await idb.describeDevice();
-  info.target_description.udid.should.eql(udid);
+  info.udid.should.eql(udid);
 }
 
 describe('idb general', function () {

--- a/test/functional/misc-commands-e2e-specs.js
+++ b/test/functional/misc-commands-e2e-specs.js
@@ -25,11 +25,9 @@ describe('idb misc commands', function () {
     await deleteDevice(simctl);
   });
 
-  // TODO: getting the description returns data in a format that is a pain
-  // to parse.
-  it.skip('describeDevice', async function () {
+  it('describeDevice', async function () {
     const info = await idb.describeDevice();
-    info.target_description.udid.should.eql(simctl.udid);
+    info.udid.should.eql(simctl.udid);
   });
 
   it('openUrl', async function () {

--- a/test/unit/helpers-specs.js
+++ b/test/unit/helpers-specs.js
@@ -1,7 +1,7 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {
-  fixOutputToArray, fixOutputToObject, convertToIDBEnv
+  fixOutputToArray, convertToIDBEnv
 } from '../../lib/helpers';
 import _ from 'lodash';
 
@@ -42,50 +42,6 @@ describe('helpers', function () {
     });
   });
 
-  describe('fixOutputToObject', function () {
-    it('should properly fix the valid output', function () {
-      const result = fixOutputToObject(`
-      target_description {
-        udid: "14EBDEDE-0C9E-46B4-B1FF-0881F11D0E75"
-        name: "iPhone X\\312\\200"
-        screen_dimensions {
-          width: 828
-          height: 1792
-          density: 2.0
-          width_points: 414
-          height_points: 896
-        }
-        state: "shutdown"
-        target_type: "simulator"
-        os_version: "iOS 12.2"
-        architecture: "x86_64"
-      }
-      `);
-      result.should.eql({
-        target_description: {
-          udid: '14EBDEDE-0C9E-46B4-B1FF-0881F11D0E75',
-          name: 'iPhone X\\312\\200',
-          screen_dimensions: {
-            width: 828,
-            height: 1792,
-            density: 2.0,
-            width_points: 414,
-            height_points: 896,
-          },
-          state: 'shutdown',
-          target_type: 'simulator',
-          os_version: 'iOS 12.2',
-          architecture: 'x86_64',
-        }
-      });
-    });
-
-    it('should properly handle an empty output', function () {
-      const result = fixOutputToObject('');
-      _.isPlainObject(result).should.be.true;
-      _.isEmpty(result).should.be.true;
-    });
-  });
   describe('convertToIDBEnv', function () {
     it('should convert to idb env', function () {
       const convertedEnvs = convertToIDBEnv({FAKE: 'ENV'});


### PR DESCRIPTION
This PR uses JSON.parse to parse  a response of `idb describe` command since it returns a valid json now.

```
idb --companion 127.0.0.1:10882 describe --udid D965CF07-8E0D-4935-9393-BEFD79CA89D6 --json
{"udid": "D965CF07-8E0D-4935-9393-BEFD79CA89D6", "name": "appium-idb-tests-7E6E1674-DC49-4CEF-B990-0E15C27493F1", "target_type": "simulator", "state": "Booted", "os_version": "iOS 16.2", "architecture": "x86_64", "companion_info": {"udid": "D965CF07-8E0D-4935-9393-BEFD79CA89D6", "is_local": true, "pid": null, "address": {"host": "127.0.0.1", "port": 10882}, "metadata": {}}, "screen_dimensions": {"width": 1242, "height": 2688, "density": 3.0, "width_points": 414, "height_points": 896}, "model": null, "device": null, "extended": {}, "diagnostics": {}, "metadata": {}}
```

I just replaced fixOutputToObject with JSON.object but it breaks backward compatibility as it looks like that it's only used in tests https://github.com/search?q=org%3Aappium+target_description&type=code  But please let me know if you need to keep it.