### PR TITLE
ci: bump xcode version to fix idb_companion server in CI

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -6,7 +6,7 @@ jobs:
   e2e:
     runs-on: macos-12
     env:
-      PLATFORM_VERSION: '15.2'
+      PLATFORM_VERSION: '16.0'
       XCODE_VERSION: '14.0'
       DEVICE_NAME: iPhone 11 Pro Max
       PYTHON_VERSION: '3.7'

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -4,10 +4,10 @@ on: [pull_request]
 
 jobs:
   e2e:
-    runs-on: macos-11
+    runs-on: macos-12
     env:
       PLATFORM_VERSION: '15.2'
-      XCODE_VERSION: '13.2'
+      XCODE_VERSION: '14.0'
       DEVICE_NAME: iPhone 11 Pro Max
       PYTHON_VERSION: '3.7'
 


### PR DESCRIPTION
This PR bumps xcode version in CI.

[I look into the current CI issue](https://github.com/appium/appium-idb/pull/65#issuecomment-1357111270) and found that idb_companion server crashes when idb is connecting to the companion server. Here is the companion server error:
```
2022-12-19 10:53:00.041+0000 Start of connect
dyld: lazy symbol binding failed: can't resolve symbol _$sScCMa in /usr/local/Cellar/idb-companion/1.1.8/bin/../Frameworks/IDBGRPCSwift.framework/Versions/A/IDBGRPCSwift because dependent dylib @rpath/libswift_Concurrency.dylib could not be loaded
dyld: can't resolve symbol _$sScCMa in /usr/local/Cellar/idb-companion/1.1.8/bin/../Frameworks/IDBGRPCSwift.framework/Versions/A/IDBGRPCSwift because dependent dylib @rpath/libswift_Concurrency.dylib could not be loaded
```
I googled the error and apparently the xcode version the CI uses has an issue with concurrency library.
https://forums.swift.org/t/swift-5-5-2-xcode-13-2-beta-fails-to-link-libswift-concurrency-dylib/53263

The runner `macos-11` [supports the xcode version up to 13.2.1](https://github.com/actions/runner-images/issues/6199#issuecomment-1303586378). so I bumped it to macos-12, which uses 14.0.1 by default.